### PR TITLE
Fix targets for git commands

### DIFF
--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -213,15 +213,13 @@ def write_nb(data: dict, file_path: str) -> None:
 def commit_changes(nbs: list):
     """Commits changes.
     """
-    set_email = ['git', 'config', '--local', 'user.email',
-                 'colab-badge-action@master']
-    set_user = ['git', 'config', '--local', 'user.name', 'Colab Badge Action']
+    set_email = ['git', 'config', 'user.email', 'colab-badge-action@master']
+    set_user = ['git', 'config', 'user.name', 'Colab Badge Action']
 
     sp.run(set_email, check=True)
     sp.run(set_user, check=True)
 
     nbs = ' '.join(set(nbs))
-    git_checkout = ['git', 'checkout', 'origin', CURRENT_BRANCH]
     git_add = ['git', 'add', nbs]
     git_commit = ['git', 'commit', '-m', 'Add/Update Colab Badges']
 

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -221,7 +221,7 @@ def commit_changes(nbs: list):
     sp.run(set_user, check=True)
 
     nbs = ' '.join(set(nbs))
-    git_checkout = ['git', 'checkout', CURRENT_BRANCH]
+    git_checkout = ['git', 'checkout', 'origin', CURRENT_BRANCH]
     git_add = ['git', 'add', nbs]
     git_commit = ['git', 'commit', '-m', 'Add/Update Colab Badges']
 

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -232,7 +232,11 @@ def commit_changes(nbs: list):
 def push_changes():
     """Pushes commit.
     """
+    set_url = ['git', 'remote', 'set-url', 'origin',
+               f'https://x-access-token:{GITHUB_TOKEN}@github.com/'
+               f'{CURRENT_REPOSITORY}']
     git_push = ['git', 'push', 'origin', CURRENT_BRANCH]
+    sp.run(set_url, check=True)
     sp.run(git_push, check=True)
 
 

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -238,12 +238,7 @@ def commit_changes(nbs: list):
 def push_changes():
     """Pushes commit.
     """
-    set_url = [
-        'git', 'remote', 'set-url', 'origin',
-        f'https://x-access-token:{GITHUB_TOKEN}@github.com/'
-        f'{CURRENT_REPOSITORY}']
     git_push = ['git', 'push', 'origin', CURRENT_BRANCH]
-    sp.check_call(set_url)
     sp.check_call(git_push)
 
 

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -212,7 +212,7 @@ def commit_changes(nbs: list):
     sp.call(set_user, shell=True)
 
     nbs = ' '.join(set(nbs))
-    git_checkout = f'git checkout {TARGET_BRANCH}'
+    git_checkout = f'git checkout {CURRENT_BRANCH}'
     git_add = f'git add {nbs}'
     git_commit = 'git commit -m "Add/Update Colab Badges"'
 
@@ -226,8 +226,8 @@ def commit_changes(nbs: list):
 def push_changes():
     """Pushes commit.
     """
-    set_url = f'git remote set-url origin https://x-access-token:{GITHUB_TOKEN}@github.com/{TARGET_REPOSITORY}'
-    git_push = f'git push origin {TARGET_BRANCH}'
+    set_url = f'git remote set-url origin https://x-access-token:{GITHUB_TOKEN}@github.com/{CURRENT_REPOSITORY}'
+    git_push = f'git push origin {CURRENT_BRANCH}'
     sp.call(set_url, shell=True)
     sp.call(git_push, shell=True)
 

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -225,7 +225,6 @@ def commit_changes(nbs: list):
 
     print(f'Committing {nbs}...')
 
-    sp.run(git_checkout, check=True)
     sp.run(git_add, check=True)
     sp.run(git_commit, check=True)
 

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -224,9 +224,9 @@ def commit_changes(nbs: list):
     sp.check_call(set_user)
 
     nbs = ' '.join(set(nbs))
-    git_checkout = f'git checkout {CURRENT_BRANCH}'
-    git_add = f'git add {nbs}'
-    git_commit = 'git commit -m "Add/Update Colab Badges"'
+    git_checkout = ['git', 'checkout', CURRENT_BRANCH]
+    git_add = ['git', 'add', nbs]
+    git_commit = ['git', 'commit', '-m', 'Add/Update Colab Badges']
 
     print(f'Committing {nbs}...')
 
@@ -238,8 +238,11 @@ def commit_changes(nbs: list):
 def push_changes():
     """Pushes commit.
     """
-    set_url = f'git remote set-url origin https://x-access-token:{GITHUB_TOKEN}@github.com/{CURRENT_REPOSITORY}'
-    git_push = f'git push origin {CURRENT_BRANCH}'
+    set_url = [
+        'git', 'remote', 'set-url', 'origin',
+        f'https://x-access-token:{GITHUB_TOKEN}@github.com/'
+        f'{CURRENT_REPOSITORY}']
+    git_push = ['git', 'push', 'origin', CURRENT_BRANCH]
     sp.check_call(set_url)
     sp.check_call(git_push)
 

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -67,8 +67,9 @@ def main():
 def get_modified_nbs() -> list:
     """Get list of all the modified notebooks in a current commit.
     """
-    cmd = 'git diff-tree --no-commit-id --name-only -r HEAD'
-    committed_files = sp.getoutput(cmd).split('\n')
+    cmd = ['git', 'diff-tree', '--no-commit-id', '--name-only', '-r', 'HEAD']
+    committed_files = sp.run(
+        cmd, check=True, capture_output=True).stdout.split('\n')
     nbs = [nb for nb in committed_files if
            (nb.endswith('.ipynb') and os.path.isfile(nb))]
     return nbs
@@ -220,8 +221,8 @@ def commit_changes(nbs: list):
                  'colab-badge-action@master']
     set_user = ['git', 'config', '--local', 'user.name', 'Colab Badge Action']
 
-    sp.check_call(set_email)
-    sp.check_call(set_user)
+    sp.run(set_email, check=True)
+    sp.run(set_user, check=True)
 
     nbs = ' '.join(set(nbs))
     git_checkout = ['git', 'checkout', CURRENT_BRANCH]
@@ -230,16 +231,16 @@ def commit_changes(nbs: list):
 
     print(f'Committing {nbs}...')
 
-    sp.check_call(git_checkout)
-    sp.check_call(git_add)
-    sp.check_call(git_commit)
+    sp.run(git_checkout, check=True)
+    sp.run(git_add, check=True)
+    sp.run(git_commit, check=True)
 
 
 def push_changes():
     """Pushes commit.
     """
     git_push = ['git', 'push', 'origin', CURRENT_BRANCH]
-    sp.check_call(git_push)
+    sp.run(git_push, check=True)
 
 
 if __name__ == '__main__':

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -208,8 +208,8 @@ def commit_changes(nbs: list):
     set_email = 'git config --local user.email "colab-badge-action@master"'
     set_user = 'git config --local user.name "Colab Badge Action"'
 
-    sp.call(set_email, shell=True)
-    sp.call(set_user, shell=True)
+    sp.check_call(set_email)
+    sp.check_call(set_user)
 
     nbs = ' '.join(set(nbs))
     git_checkout = f'git checkout {CURRENT_BRANCH}'
@@ -218,9 +218,9 @@ def commit_changes(nbs: list):
 
     print(f'Committing {nbs}...')
 
-    sp.call(git_checkout, shell=True)
-    sp.call(git_add, shell=True)
-    sp.call(git_commit, shell=True)
+    sp.check_call(git_checkout)
+    sp.check_call(git_add)
+    sp.check_call(git_commit)
 
 
 def push_changes():
@@ -228,8 +228,8 @@ def push_changes():
     """
     set_url = f'git remote set-url origin https://x-access-token:{GITHUB_TOKEN}@github.com/{CURRENT_REPOSITORY}'
     git_push = f'git push origin {CURRENT_BRANCH}'
-    sp.call(set_url, shell=True)
-    sp.call(git_push, shell=True)
+    sp.check_call(set_url)
+    sp.check_call(git_push)
 
 
 if __name__ == '__main__':

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -208,8 +208,8 @@ def commit_changes(nbs: list):
     set_email = 'git config --local user.email "colab-badge-action@master"'
     set_user = 'git config --local user.name "Colab Badge Action"'
 
-    sp.check_call(set_email)
-    sp.check_call(set_user)
+    sp.call(set_email, shell=True)
+    sp.call(set_user, shell=True)
 
     nbs = ' '.join(set(nbs))
     git_checkout = f'git checkout {CURRENT_BRANCH}'
@@ -218,9 +218,9 @@ def commit_changes(nbs: list):
 
     print(f'Committing {nbs}...')
 
-    sp.check_call(git_checkout)
-    sp.check_call(git_add)
-    sp.check_call(git_commit)
+    sp.call(git_checkout, shell=True)
+    sp.call(git_add, shell=True)
+    sp.call(git_commit, shell=True)
 
 
 def push_changes():
@@ -228,8 +228,8 @@ def push_changes():
     """
     set_url = f'git remote set-url origin https://x-access-token:{GITHUB_TOKEN}@github.com/{CURRENT_REPOSITORY}'
     git_push = f'git push origin {CURRENT_BRANCH}'
-    sp.check_call(set_url)
-    sp.check_call(git_push)
+    sp.call(set_url, shell=True)
+    sp.call(git_push, shell=True)
 
 
 if __name__ == '__main__':

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -36,10 +36,6 @@ UPDATE = os.environ['INPUT_UPDATE']
 def main():
     """Sic Mundus Creatus Est.
     """
-    if (GITHUB_EVENT_NAME == 'pull_request') and (
-            GITHUB_ACTOR != GITHUB_REPOSITORY_OWNER):
-        return
-
     if CHECK:
         if CHECK == 'all':
             nbs = get_all_nbs()


### PR DESCRIPTION
The `TARGET_*` variables should only be used to adjust what the badge points to, not what the `git` commands target. Likely the user will not have permission to push to the target branch/repo, which is why these variables exist.